### PR TITLE
fix: hierarchy bottom up, avoid @ContentChildren

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -24,7 +24,7 @@ Supported Angular version: `16`.
 - [Inner events](#inner-events)
   - [ko-layer](#ko-layer)
   - [ko-stage](#ko-stage)
-  - [ko-shape](#ko-shape)
+  - [ko-nestable](#ko-nestable)
 - [How to contribute](#how-to-contribute)
   - [Event listeners](#event-listeners)
 - [Full API Documentation](#full-api-documentation)

--- a/docs/classes/KoDragDirective.md
+++ b/docs/classes/KoDragDirective.md
@@ -46,7 +46,7 @@
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-drag.directive.ts:24](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-drag.directive.ts#L24)
+[projects/ngx-konva/src/lib/directives/ko-drag.directive.ts:24](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-drag.directive.ts#L24)
 
 ## Properties
 
@@ -56,7 +56,7 @@
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-drag.directive.ts:16](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-drag.directive.ts#L16)
+[projects/ngx-konva/src/lib/directives/ko-drag.directive.ts:16](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-drag.directive.ts#L16)
 
 ___
 
@@ -66,7 +66,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-drag.directive.ts:13](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-drag.directive.ts#L13)
+[projects/ngx-konva/src/lib/directives/ko-drag.directive.ts:13](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-drag.directive.ts#L13)
 
 ___
 
@@ -76,7 +76,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-drag.directive.ts:10](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-drag.directive.ts#L10)
+[projects/ngx-konva/src/lib/directives/ko-drag.directive.ts:10](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-drag.directive.ts#L10)
 
 ___
 
@@ -86,7 +86,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-drag.directive.ts:18](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-drag.directive.ts#L18)
+[projects/ngx-konva/src/lib/directives/ko-drag.directive.ts:18](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-drag.directive.ts#L18)
 
 ___
 
@@ -104,7 +104,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-drag.directive.ts:21](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-drag.directive.ts#L21)
+[projects/ngx-konva/src/lib/directives/ko-drag.directive.ts:21](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-drag.directive.ts#L21)
 
 ___
 
@@ -122,7 +122,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-drag.directive.ts:22](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-drag.directive.ts#L22)
+[projects/ngx-konva/src/lib/directives/ko-drag.directive.ts:22](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-drag.directive.ts#L22)
 
 ___
 
@@ -140,7 +140,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-drag.directive.ts:20](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-drag.directive.ts#L20)
+[projects/ngx-konva/src/lib/directives/ko-drag.directive.ts:20](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-drag.directive.ts#L20)
 
 ## Methods
 
@@ -154,7 +154,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-drag.directive.ts:45](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-drag.directive.ts#L45)
+[projects/ngx-konva/src/lib/directives/ko-drag.directive.ts:45](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-drag.directive.ts#L45)
 
 ___
 
@@ -172,7 +172,7 @@ OnDestroy.ngOnDestroy
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-drag.directive.ts:38](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-drag.directive.ts#L38)
+[projects/ngx-konva/src/lib/directives/ko-drag.directive.ts:38](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-drag.directive.ts#L38)
 
 ___
 
@@ -190,7 +190,7 @@ OnInit.ngOnInit
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-drag.directive.ts:35](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-drag.directive.ts#L35)
+[projects/ngx-konva/src/lib/directives/ko-drag.directive.ts:35](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-drag.directive.ts#L35)
 
 ___
 
@@ -204,7 +204,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-drag.directive.ts:55](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-drag.directive.ts#L55)
+[projects/ngx-konva/src/lib/directives/ko-drag.directive.ts:55](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-drag.directive.ts#L55)
 
 ___
 
@@ -218,7 +218,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-drag.directive.ts:59](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-drag.directive.ts#L59)
+[projects/ngx-konva/src/lib/directives/ko-drag.directive.ts:59](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-drag.directive.ts#L59)
 
 ___
 
@@ -232,4 +232,4 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-drag.directive.ts:51](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-drag.directive.ts#L51)
+[projects/ngx-konva/src/lib/directives/ko-drag.directive.ts:51](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-drag.directive.ts#L51)

--- a/docs/classes/KoGroupComponent.md
+++ b/docs/classes/KoGroupComponent.md
@@ -26,9 +26,9 @@
 - [\_tweenTimeout](KoGroupComponent.md#_tweentimeout)
 - [afterUpdate](KoGroupComponent.md#afterupdate)
 - [beforeUpdate](KoGroupComponent.md#beforeupdate)
-- [children](KoGroupComponent.md#children)
 - [group](KoGroupComponent.md#group)
 - [id](KoGroupComponent.md#id)
+- [layerComponent](KoGroupComponent.md#layercomponent)
 - [onNewItem](KoGroupComponent.md#onnewitem)
 - [sub](KoGroupComponent.md#sub)
 - [transitionDelay](KoGroupComponent.md#transitiondelay)
@@ -43,19 +43,25 @@
 
 ### Methods
 
+- [addChild](KoGroupComponent.md#addchild)
 - [getKoItem](KoGroupComponent.md#getkoitem)
 - [ngAfterViewInit](KoGroupComponent.md#ngafterviewinit)
 - [ngOnDestroy](KoGroupComponent.md#ngondestroy)
 - [ngOnInit](KoGroupComponent.md#ngoninit)
 - [setConfig](KoGroupComponent.md#setconfig)
-- [updateChildren](KoGroupComponent.md#updatechildren)
 - [updateGroup](KoGroupComponent.md#updategroup)
 
 ## Constructors
 
 ### constructor
 
-• **new KoGroupComponent**()
+• **new KoGroupComponent**(`layerComponent`)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `layerComponent` | [`KoLayerComponent`](KoLayerComponent.md) |
 
 #### Overrides
 
@@ -63,7 +69,7 @@
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-group.component.ts:39](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-group.component.ts#L39)
+[projects/ngx-konva/src/lib/components/ko-group.component.ts:37](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-group.component.ts#L37)
 
 ## Properties
 
@@ -73,7 +79,7 @@
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-group.component.ts:22](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-group.component.ts#L22)
+[projects/ngx-konva/src/lib/components/ko-group.component.ts:20](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-group.component.ts#L20)
 
 ___
 
@@ -87,7 +93,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:33](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L33)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:34](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L34)
 
 ___
 
@@ -101,7 +107,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:34](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L34)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:35](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L35)
 
 ___
 
@@ -111,7 +117,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-group.component.ts:37](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-group.component.ts#L37)
+[projects/ngx-konva/src/lib/components/ko-group.component.ts:35](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-group.component.ts#L35)
 
 ___
 
@@ -121,17 +127,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-group.component.ts:34](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-group.component.ts#L34)
-
-___
-
-### children
-
-• `Private` **children**: `QueryList`<[`KoNestable`](KoNestable.md)\>
-
-#### Defined in
-
-[projects/ngx-konva/src/lib/components/ko-group.component.ts:18](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-group.component.ts#L18)
+[projects/ngx-konva/src/lib/components/ko-group.component.ts:32](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-group.component.ts#L32)
 
 ___
 
@@ -141,7 +137,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-group.component.ts:20](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-group.component.ts#L20)
+[projects/ngx-konva/src/lib/components/ko-group.component.ts:18](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-group.component.ts#L18)
 
 ___
 
@@ -155,7 +151,17 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:17](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L17)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:18](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L18)
+
+___
+
+### layerComponent
+
+• `Private` **layerComponent**: [`KoLayerComponent`](KoLayerComponent.md)
+
+#### Defined in
+
+[projects/ngx-konva/src/lib/components/ko-group.component.ts:38](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-group.component.ts#L38)
 
 ___
 
@@ -165,7 +171,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-group.component.ts:31](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-group.component.ts#L31)
+[projects/ngx-konva/src/lib/components/ko-group.component.ts:29](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-group.component.ts#L29)
 
 ___
 
@@ -179,7 +185,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:31](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L31)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:32](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L32)
 
 ___
 
@@ -193,7 +199,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:23](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L23)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:24](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L24)
 
 ___
 
@@ -207,7 +213,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:29](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L29)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:30](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L30)
 
 ___
 
@@ -221,7 +227,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:26](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L26)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:27](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L27)
 
 ___
 
@@ -235,7 +241,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:20](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L20)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:21](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L21)
 
 ___
 
@@ -270,7 +276,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:15](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L15)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:15](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L15)
 
 ## Accessors
 
@@ -290,9 +296,29 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-group.component.ts:24](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-group.component.ts#L24)
+[projects/ngx-konva/src/lib/components/ko-group.component.ts:22](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-group.component.ts#L22)
 
 ## Methods
+
+### addChild
+
+▸ **addChild**(`child`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `child` | [`KoNestableNode`](../modules.md#konestablenode) |
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[projects/ngx-konva/src/lib/components/ko-group.component.ts:62](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-group.component.ts#L62)
+
+___
 
 ### getKoItem
 
@@ -308,7 +334,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-group.component.ts:58](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-group.component.ts#L58)
+[projects/ngx-konva/src/lib/components/ko-group.component.ts:52](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-group.component.ts#L52)
 
 ___
 
@@ -326,7 +352,7 @@ AfterViewInit.ngAfterViewInit
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-group.component.ts:48](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-group.component.ts#L48)
+[projects/ngx-konva/src/lib/components/ko-group.component.ts:49](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-group.component.ts#L49)
 
 ___
 
@@ -344,7 +370,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:43](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L43)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:44](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L44)
 
 ___
 
@@ -366,7 +392,7 @@ OnInit.ngOnInit
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-group.component.ts:44](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-group.component.ts#L44)
+[projects/ngx-konva/src/lib/components/ko-group.component.ts:45](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-group.component.ts#L45)
 
 ___
 
@@ -390,21 +416,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:48](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L48)
-
-___
-
-### updateChildren
-
-▸ `Private` **updateChildren**(): `void`
-
-#### Returns
-
-`void`
-
-#### Defined in
-
-[projects/ngx-konva/src/lib/components/ko-group.component.ts:68](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-group.component.ts#L68)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:49](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L49)
 
 ___
 
@@ -418,4 +430,4 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-group.component.ts:62](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-group.component.ts#L62)
+[projects/ngx-konva/src/lib/components/ko-group.component.ts:56](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-group.component.ts#L56)

--- a/docs/classes/KoHoverDirective.md
+++ b/docs/classes/KoHoverDirective.md
@@ -44,7 +44,7 @@
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-hover.directive.ts:23](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-hover.directive.ts#L23)
+[projects/ngx-konva/src/lib/directives/ko-hover.directive.ts:23](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-hover.directive.ts#L23)
 
 ## Properties
 
@@ -54,7 +54,7 @@
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-hover.directive.ts:16](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-hover.directive.ts#L16)
+[projects/ngx-konva/src/lib/directives/ko-hover.directive.ts:16](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-hover.directive.ts#L16)
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-hover.directive.ts:14](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-hover.directive.ts#L14)
+[projects/ngx-konva/src/lib/directives/ko-hover.directive.ts:14](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-hover.directive.ts#L14)
 
 ___
 
@@ -74,7 +74,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-hover.directive.ts:11](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-hover.directive.ts#L11)
+[projects/ngx-konva/src/lib/directives/ko-hover.directive.ts:11](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-hover.directive.ts#L11)
 
 ___
 
@@ -84,7 +84,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-hover.directive.ts:18](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-hover.directive.ts#L18)
+[projects/ngx-konva/src/lib/directives/ko-hover.directive.ts:18](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-hover.directive.ts#L18)
 
 ___
 
@@ -102,7 +102,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-hover.directive.ts:20](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-hover.directive.ts#L20)
+[projects/ngx-konva/src/lib/directives/ko-hover.directive.ts:20](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-hover.directive.ts#L20)
 
 ___
 
@@ -120,7 +120,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-hover.directive.ts:21](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-hover.directive.ts#L21)
+[projects/ngx-konva/src/lib/directives/ko-hover.directive.ts:21](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-hover.directive.ts#L21)
 
 ## Methods
 
@@ -134,7 +134,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-hover.directive.ts:43](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-hover.directive.ts#L43)
+[projects/ngx-konva/src/lib/directives/ko-hover.directive.ts:43](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-hover.directive.ts#L43)
 
 ___
 
@@ -152,7 +152,7 @@ OnDestroy.ngOnDestroy
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-hover.directive.ts:37](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-hover.directive.ts#L37)
+[projects/ngx-konva/src/lib/directives/ko-hover.directive.ts:37](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-hover.directive.ts#L37)
 
 ___
 
@@ -170,7 +170,7 @@ OnInit.ngOnInit
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-hover.directive.ts:34](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-hover.directive.ts#L34)
+[projects/ngx-konva/src/lib/directives/ko-hover.directive.ts:34](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-hover.directive.ts#L34)
 
 ___
 
@@ -184,7 +184,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-hover.directive.ts:48](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-hover.directive.ts#L48)
+[projects/ngx-konva/src/lib/directives/ko-hover.directive.ts:48](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-hover.directive.ts#L48)
 
 ___
 
@@ -198,4 +198,4 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-hover.directive.ts:53](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-hover.directive.ts#L53)
+[projects/ngx-konva/src/lib/directives/ko-hover.directive.ts:53](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-hover.directive.ts#L53)

--- a/docs/classes/KoImageComponent.md
+++ b/docs/classes/KoImageComponent.md
@@ -28,7 +28,9 @@
 - [afterUpdate](KoImageComponent.md#afterupdate)
 - [beforeUpdate](KoImageComponent.md#beforeupdate)
 - [centerOrigin](KoImageComponent.md#centerorigin)
+- [groupComponent](KoImageComponent.md#groupcomponent)
 - [id](KoImageComponent.md#id)
+- [layerComponent](KoImageComponent.md#layercomponent)
 - [node](KoImageComponent.md#node)
 - [onLoadListener](KoImageComponent.md#onloadlistener)
 - [sub](KoImageComponent.md#sub)
@@ -58,7 +60,14 @@
 
 ### constructor
 
-• **new KoImageComponent**()
+• **new KoImageComponent**(`layerComponent`, `groupComponent`)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `layerComponent` | [`KoLayerComponent`](KoLayerComponent.md) |
+| `groupComponent` | [`KoGroupComponent`](KoGroupComponent.md) |
 
 #### Overrides
 
@@ -66,7 +75,7 @@
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-image.component.ts:48](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-image.component.ts#L48)
+[projects/ngx-konva/src/lib/components/ko-image.component.ts:50](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-image.component.ts#L50)
 
 ## Properties
 
@@ -76,7 +85,7 @@
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-image.component.ts:29](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-image.component.ts#L29)
+[projects/ngx-konva/src/lib/components/ko-image.component.ts:31](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-image.component.ts#L31)
 
 ___
 
@@ -86,7 +95,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-image.component.ts:20](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-image.component.ts#L20)
+[projects/ngx-konva/src/lib/components/ko-image.component.ts:22](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-image.component.ts#L22)
 
 ___
 
@@ -96,7 +105,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-image.component.ts:22](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-image.component.ts#L22)
+[projects/ngx-konva/src/lib/components/ko-image.component.ts:24](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-image.component.ts#L24)
 
 ___
 
@@ -110,7 +119,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:33](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L33)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:34](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L34)
 
 ___
 
@@ -124,7 +133,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:34](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L34)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:35](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L35)
 
 ___
 
@@ -134,7 +143,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-image.component.ts:44](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-image.component.ts#L44)
+[projects/ngx-konva/src/lib/components/ko-image.component.ts:46](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-image.component.ts#L46)
 
 ___
 
@@ -144,7 +153,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-image.component.ts:41](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-image.component.ts#L41)
+[projects/ngx-konva/src/lib/components/ko-image.component.ts:43](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-image.component.ts#L43)
 
 ___
 
@@ -154,7 +163,17 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-image.component.ts:38](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-image.component.ts#L38)
+[projects/ngx-konva/src/lib/components/ko-image.component.ts:40](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-image.component.ts#L40)
+
+___
+
+### groupComponent
+
+• `Private` **groupComponent**: [`KoGroupComponent`](KoGroupComponent.md)
+
+#### Defined in
+
+[projects/ngx-konva/src/lib/components/ko-image.component.ts:52](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-image.component.ts#L52)
 
 ___
 
@@ -168,7 +187,17 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:17](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L17)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:18](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L18)
+
+___
+
+### layerComponent
+
+• `Private` **layerComponent**: [`KoLayerComponent`](KoLayerComponent.md)
+
+#### Defined in
+
+[projects/ngx-konva/src/lib/components/ko-image.component.ts:51](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-image.component.ts#L51)
 
 ___
 
@@ -178,7 +207,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-image.component.ts:18](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-image.component.ts#L18)
+[projects/ngx-konva/src/lib/components/ko-image.component.ts:20](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-image.component.ts#L20)
 
 ___
 
@@ -196,7 +225,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-image.component.ts:46](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-image.component.ts#L46)
+[projects/ngx-konva/src/lib/components/ko-image.component.ts:48](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-image.component.ts#L48)
 
 ___
 
@@ -210,7 +239,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:31](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L31)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:32](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L32)
 
 ___
 
@@ -224,7 +253,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:23](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L23)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:24](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L24)
 
 ___
 
@@ -238,7 +267,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:29](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L29)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:30](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L30)
 
 ___
 
@@ -252,7 +281,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:26](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L26)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:27](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L27)
 
 ___
 
@@ -266,7 +295,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:20](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L20)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:21](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L21)
 
 ___
 
@@ -301,7 +330,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:15](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L15)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:15](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L15)
 
 ## Accessors
 
@@ -321,7 +350,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-image.component.ts:31](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-image.component.ts#L31)
+[projects/ngx-konva/src/lib/components/ko-image.component.ts:33](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-image.component.ts#L33)
 
 ___
 
@@ -341,7 +370,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-image.component.ts:24](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-image.component.ts#L24)
+[projects/ngx-konva/src/lib/components/ko-image.component.ts:26](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-image.component.ts#L26)
 
 ## Methods
 
@@ -355,7 +384,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-image.component.ts:78](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-image.component.ts#L78)
+[projects/ngx-konva/src/lib/components/ko-image.component.ts:88](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-image.component.ts#L88)
 
 ___
 
@@ -369,7 +398,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-image.component.ts:74](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-image.component.ts#L74)
+[projects/ngx-konva/src/lib/components/ko-image.component.ts:84](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-image.component.ts#L84)
 
 ___
 
@@ -387,7 +416,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-image.component.ts:62](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-image.component.ts#L62)
+[projects/ngx-konva/src/lib/components/ko-image.component.ts:72](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-image.component.ts#L72)
 
 ___
 
@@ -405,7 +434,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-image.component.ts:57](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-image.component.ts#L57)
+[projects/ngx-konva/src/lib/components/ko-image.component.ts:67](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-image.component.ts#L67)
 
 ___
 
@@ -427,7 +456,7 @@ OnInit.ngOnInit
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:41](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L41)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:42](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L42)
 
 ___
 
@@ -441,7 +470,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-image.component.ts:87](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-image.component.ts#L87)
+[projects/ngx-konva/src/lib/components/ko-image.component.ts:97](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-image.component.ts#L97)
 
 ___
 
@@ -465,7 +494,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:48](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L48)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:49](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L49)
 
 ___
 
@@ -479,4 +508,4 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-image.component.ts:66](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-image.component.ts#L66)
+[projects/ngx-konva/src/lib/components/ko-image.component.ts:76](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-image.component.ts#L76)

--- a/docs/classes/KoLabelComponent.md
+++ b/docs/classes/KoLabelComponent.md
@@ -28,7 +28,9 @@
 - [afterUpdate](KoLabelComponent.md#afterupdate)
 - [beforeUpdate](KoLabelComponent.md#beforeupdate)
 - [centerOrigin](KoLabelComponent.md#centerorigin)
+- [groupComponent](KoLabelComponent.md#groupcomponent)
 - [id](KoLabelComponent.md#id)
+- [layerComponent](KoLabelComponent.md#layercomponent)
 - [node](KoLabelComponent.md#node)
 - [sub](KoLabelComponent.md#sub)
 - [tag](KoLabelComponent.md#tag)
@@ -63,7 +65,14 @@
 
 ### constructor
 
-• **new KoLabelComponent**()
+• **new KoLabelComponent**(`layerComponent`, `groupComponent`)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `layerComponent` | [`KoLayerComponent`](KoLayerComponent.md) |
+| `groupComponent` | [`KoGroupComponent`](KoGroupComponent.md) |
 
 #### Overrides
 
@@ -71,7 +80,7 @@
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-label.component.ts:69](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-label.component.ts#L69)
+[projects/ngx-konva/src/lib/components/ko-label.component.ts:71](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-label.component.ts#L71)
 
 ## Properties
 
@@ -81,7 +90,7 @@
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-label.component.ts:20](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-label.component.ts#L20)
+[projects/ngx-konva/src/lib/components/ko-label.component.ts:22](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-label.component.ts#L22)
 
 ___
 
@@ -91,7 +100,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-label.component.ts:35](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-label.component.ts#L35)
+[projects/ngx-konva/src/lib/components/ko-label.component.ts:37](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-label.component.ts#L37)
 
 ___
 
@@ -101,7 +110,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-label.component.ts:28](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-label.component.ts#L28)
+[projects/ngx-konva/src/lib/components/ko-label.component.ts:30](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-label.component.ts#L30)
 
 ___
 
@@ -115,7 +124,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:33](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L33)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:34](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L34)
 
 ___
 
@@ -129,7 +138,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:34](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L34)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:35](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L35)
 
 ___
 
@@ -139,7 +148,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-label.component.ts:67](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-label.component.ts#L67)
+[projects/ngx-konva/src/lib/components/ko-label.component.ts:69](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-label.component.ts#L69)
 
 ___
 
@@ -149,7 +158,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-label.component.ts:64](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-label.component.ts#L64)
+[projects/ngx-konva/src/lib/components/ko-label.component.ts:66](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-label.component.ts#L66)
 
 ___
 
@@ -159,7 +168,17 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-label.component.ts:61](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-label.component.ts#L61)
+[projects/ngx-konva/src/lib/components/ko-label.component.ts:63](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-label.component.ts#L63)
+
+___
+
+### groupComponent
+
+• `Private` **groupComponent**: [`KoGroupComponent`](KoGroupComponent.md)
+
+#### Defined in
+
+[projects/ngx-konva/src/lib/components/ko-label.component.ts:73](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-label.component.ts#L73)
 
 ___
 
@@ -173,7 +192,17 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:17](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L17)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:18](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L18)
+
+___
+
+### layerComponent
+
+• `Private` **layerComponent**: [`KoLayerComponent`](KoLayerComponent.md)
+
+#### Defined in
+
+[projects/ngx-konva/src/lib/components/ko-label.component.ts:72](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-label.component.ts#L72)
 
 ___
 
@@ -183,7 +212,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-label.component.ts:16](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-label.component.ts#L16)
+[projects/ngx-konva/src/lib/components/ko-label.component.ts:18](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-label.component.ts#L18)
 
 ___
 
@@ -197,7 +226,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:31](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L31)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:32](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L32)
 
 ___
 
@@ -207,7 +236,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-label.component.ts:18](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-label.component.ts#L18)
+[projects/ngx-konva/src/lib/components/ko-label.component.ts:20](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-label.component.ts#L20)
 
 ___
 
@@ -217,7 +246,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-label.component.ts:17](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-label.component.ts#L17)
+[projects/ngx-konva/src/lib/components/ko-label.component.ts:19](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-label.component.ts#L19)
 
 ___
 
@@ -231,7 +260,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:23](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L23)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:24](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L24)
 
 ___
 
@@ -245,7 +274,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:29](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L29)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:30](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L30)
 
 ___
 
@@ -259,7 +288,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:26](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L26)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:27](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L27)
 
 ___
 
@@ -273,7 +302,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:20](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L20)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:21](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L21)
 
 ___
 
@@ -308,7 +337,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:15](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L15)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:15](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L15)
 
 ## Accessors
 
@@ -328,7 +357,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-label.component.ts:22](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-label.component.ts#L22)
+[projects/ngx-konva/src/lib/components/ko-label.component.ts:24](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-label.component.ts#L24)
 
 ___
 
@@ -348,7 +377,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-label.component.ts:37](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-label.component.ts#L37)
+[projects/ngx-konva/src/lib/components/ko-label.component.ts:39](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-label.component.ts#L39)
 
 ___
 
@@ -368,7 +397,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-label.component.ts:43](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-label.component.ts#L43)
+[projects/ngx-konva/src/lib/components/ko-label.component.ts:45](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-label.component.ts#L45)
 
 ___
 
@@ -388,7 +417,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-label.component.ts:30](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-label.component.ts#L30)
+[projects/ngx-konva/src/lib/components/ko-label.component.ts:32](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-label.component.ts#L32)
 
 ___
 
@@ -408,7 +437,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-label.component.ts:52](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-label.component.ts#L52)
+[projects/ngx-konva/src/lib/components/ko-label.component.ts:54](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-label.component.ts#L54)
 
 ## Methods
 
@@ -422,7 +451,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-label.component.ts:115](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-label.component.ts#L115)
+[projects/ngx-konva/src/lib/components/ko-label.component.ts:124](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-label.component.ts#L124)
 
 ___
 
@@ -436,7 +465,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-label.component.ts:111](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-label.component.ts#L111)
+[projects/ngx-konva/src/lib/components/ko-label.component.ts:120](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-label.component.ts#L120)
 
 ___
 
@@ -454,7 +483,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-label.component.ts:85](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-label.component.ts#L85)
+[projects/ngx-konva/src/lib/components/ko-label.component.ts:94](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-label.component.ts#L94)
 
 ___
 
@@ -472,7 +501,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-label.component.ts:81](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-label.component.ts#L81)
+[projects/ngx-konva/src/lib/components/ko-label.component.ts:90](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-label.component.ts#L90)
 
 ___
 
@@ -494,7 +523,7 @@ OnInit.ngOnInit
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:41](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L41)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:42](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L42)
 
 ___
 
@@ -518,7 +547,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:48](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L48)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:49](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L49)
 
 ___
 
@@ -532,7 +561,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-label.component.ts:97](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-label.component.ts#L97)
+[projects/ngx-konva/src/lib/components/ko-label.component.ts:106](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-label.component.ts#L106)
 
 ___
 
@@ -546,7 +575,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-label.component.ts:103](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-label.component.ts#L103)
+[projects/ngx-konva/src/lib/components/ko-label.component.ts:112](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-label.component.ts#L112)
 
 ___
 
@@ -560,4 +589,4 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-label.component.ts:89](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-label.component.ts#L89)
+[projects/ngx-konva/src/lib/components/ko-label.component.ts:98](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-label.component.ts#L98)

--- a/docs/classes/KoLayerComponent.md
+++ b/docs/classes/KoLayerComponent.md
@@ -27,10 +27,11 @@
 - [\_tweenTimeout](KoLayerComponent.md#_tweentimeout)
 - [afterUpdate](KoLayerComponent.md#afterupdate)
 - [beforeUpdate](KoLayerComponent.md#beforeupdate)
-- [children](KoLayerComponent.md#children)
 - [id](KoLayerComponent.md#id)
 - [layer](KoLayerComponent.md#layer)
+- [layerComponent](KoLayerComponent.md#layercomponent)
 - [onNewItem](KoLayerComponent.md#onnewitem)
+- [stageComponent](KoLayerComponent.md#stagecomponent)
 - [sub](KoLayerComponent.md#sub)
 - [transitionDelay](KoLayerComponent.md#transitiondelay)
 - [transitionOnFinish](KoLayerComponent.md#transitiononfinish)
@@ -44,19 +45,27 @@
 
 ### Methods
 
+- [addChild](KoLayerComponent.md#addchild)
 - [getKoItem](KoLayerComponent.md#getkoitem)
 - [ngAfterViewInit](KoLayerComponent.md#ngafterviewinit)
 - [ngOnDestroy](KoLayerComponent.md#ngondestroy)
 - [ngOnInit](KoLayerComponent.md#ngoninit)
 - [setConfig](KoLayerComponent.md#setconfig)
-- [updateChildren](KoLayerComponent.md#updatechildren)
 - [updateLayer](KoLayerComponent.md#updatelayer)
 
 ## Constructors
 
 ### constructor
 
-• **new KoLayerComponent**()
+• **new KoLayerComponent**(`stageComponent?`, `stageAutoComponent?`, `layerComponent?`)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `stageComponent?` | [`KoStageComponent`](KoStageComponent.md) |
+| `stageAutoComponent?` | [`KoStageAutoScaleComponent`](KoStageAutoScaleComponent.md) |
+| `layerComponent?` | [`KoLayerComponent`](KoLayerComponent.md) |
 
 #### Overrides
 
@@ -64,17 +73,17 @@
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-layer.component.ts:41](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-layer.component.ts#L41)
+[projects/ngx-konva/src/lib/components/ko-layer.component.ts:43](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-layer.component.ts#L43)
 
 ## Properties
 
 ### \_config
 
-• `Private` **\_config**: [`KoNestableConfig`](../modules.md#konestableconfig) = `{}`
+• `Private` **\_config**: [`KoNestableConfig`](../modules.md#konestableconfig)
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-layer.component.ts:23](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-layer.component.ts#L23)
+[projects/ngx-konva/src/lib/components/ko-layer.component.ts:23](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-layer.component.ts#L23)
 
 ___
 
@@ -88,7 +97,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:33](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L33)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:34](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L34)
 
 ___
 
@@ -102,7 +111,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:34](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L34)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:35](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L35)
 
 ___
 
@@ -112,7 +121,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-layer.component.ts:39](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-layer.component.ts#L39)
+[projects/ngx-konva/src/lib/components/ko-layer.component.ts:41](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-layer.component.ts#L41)
 
 ___
 
@@ -122,17 +131,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-layer.component.ts:36](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-layer.component.ts#L36)
-
-___
-
-### children
-
-• **children**: `QueryList`<[`KoNestable`](KoNestable.md)\>
-
-#### Defined in
-
-[projects/ngx-konva/src/lib/components/ko-layer.component.ts:19](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-layer.component.ts#L19)
+[projects/ngx-konva/src/lib/components/ko-layer.component.ts:38](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-layer.component.ts#L38)
 
 ___
 
@@ -146,7 +145,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:17](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L17)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:18](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L18)
 
 ___
 
@@ -156,7 +155,17 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-layer.component.ts:21](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-layer.component.ts#L21)
+[projects/ngx-konva/src/lib/components/ko-layer.component.ts:20](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-layer.component.ts#L20)
+
+___
+
+### layerComponent
+
+• `Private` `Optional` **layerComponent**: [`KoLayerComponent`](KoLayerComponent.md)
+
+#### Defined in
+
+[projects/ngx-konva/src/lib/components/ko-layer.component.ts:46](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-layer.component.ts#L46)
 
 ___
 
@@ -166,7 +175,17 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-layer.component.ts:33](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-layer.component.ts#L33)
+[projects/ngx-konva/src/lib/components/ko-layer.component.ts:35](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-layer.component.ts#L35)
+
+___
+
+### stageComponent
+
+• **stageComponent**: [`KoStageComponent`](KoStageComponent.md)
+
+#### Defined in
+
+[projects/ngx-konva/src/lib/components/ko-layer.component.ts:21](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-layer.component.ts#L21)
 
 ___
 
@@ -180,7 +199,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:31](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L31)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:32](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L32)
 
 ___
 
@@ -194,7 +213,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:23](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L23)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:24](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L24)
 
 ___
 
@@ -208,7 +227,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:29](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L29)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:30](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L30)
 
 ___
 
@@ -222,7 +241,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:26](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L26)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:27](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L27)
 
 ___
 
@@ -236,7 +255,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:20](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L20)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:21](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L21)
 
 ___
 
@@ -271,7 +290,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:15](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L15)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:15](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L15)
 
 ## Accessors
 
@@ -291,9 +310,29 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-layer.component.ts:26](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-layer.component.ts#L26)
+[projects/ngx-konva/src/lib/components/ko-layer.component.ts:28](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-layer.component.ts#L28)
 
 ## Methods
+
+### addChild
+
+▸ **addChild**(`child`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `child` | [`KoNestableNode`](../modules.md#konestablenode) |
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[projects/ngx-konva/src/lib/components/ko-layer.component.ts:81](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-layer.component.ts#L81)
+
+___
 
 ### getKoItem
 
@@ -309,7 +348,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-layer.component.ts:57](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-layer.component.ts#L57)
+[projects/ngx-konva/src/lib/components/ko-layer.component.ts:70](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-layer.component.ts#L70)
 
 ___
 
@@ -327,7 +366,7 @@ AfterViewInit.ngAfterViewInit
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-layer.component.ts:50](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-layer.component.ts#L50)
+[projects/ngx-konva/src/lib/components/ko-layer.component.ts:67](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-layer.component.ts#L67)
 
 ___
 
@@ -349,7 +388,7 @@ OnDestroy.ngOnDestroy
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:43](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L43)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:44](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L44)
 
 ___
 
@@ -371,7 +410,7 @@ OnInit.ngOnInit
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-layer.component.ts:46](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-layer.component.ts#L46)
+[projects/ngx-konva/src/lib/components/ko-layer.component.ts:63](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-layer.component.ts#L63)
 
 ___
 
@@ -395,21 +434,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:48](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L48)
-
-___
-
-### updateChildren
-
-▸ `Private` **updateChildren**(): `void`
-
-#### Returns
-
-`void`
-
-#### Defined in
-
-[projects/ngx-konva/src/lib/components/ko-layer.component.ts:68](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-layer.component.ts#L68)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:49](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L49)
 
 ___
 
@@ -423,4 +448,4 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-layer.component.ts:61](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-layer.component.ts#L61)
+[projects/ngx-konva/src/lib/components/ko-layer.component.ts:74](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-layer.component.ts#L74)

--- a/docs/classes/KoNestable.md
+++ b/docs/classes/KoNestable.md
@@ -61,7 +61,7 @@
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:35](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L35)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:36](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L36)
 
 ___
 
@@ -71,7 +71,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:33](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L33)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:34](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L34)
 
 ___
 
@@ -81,7 +81,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:34](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L34)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:35](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L35)
 
 ___
 
@@ -91,7 +91,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:17](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L17)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:18](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L18)
 
 ___
 
@@ -101,7 +101,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:31](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L31)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:32](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L32)
 
 ___
 
@@ -111,7 +111,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:23](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L23)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:24](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L24)
 
 ___
 
@@ -121,7 +121,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:29](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L29)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:30](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L30)
 
 ___
 
@@ -131,7 +131,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:26](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L26)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:27](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L27)
 
 ___
 
@@ -141,7 +141,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:20](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L20)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:21](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L21)
 
 ___
 
@@ -172,7 +172,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:15](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L15)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:15](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L15)
 
 ## Methods
 
@@ -186,7 +186,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:37](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L37)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:38](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L38)
 
 ___
 
@@ -204,7 +204,7 @@ OnDestroy.ngOnDestroy
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:43](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L43)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:44](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L44)
 
 ___
 
@@ -222,7 +222,7 @@ OnInit.ngOnInit
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:41](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L41)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:42](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L42)
 
 ___
 
@@ -242,4 +242,4 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:48](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L48)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:49](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L49)

--- a/docs/classes/KoPointerDirective.md
+++ b/docs/classes/KoPointerDirective.md
@@ -69,7 +69,7 @@
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:56](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L56)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:56](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L56)
 
 ## Properties
 
@@ -79,7 +79,7 @@
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:40](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L40)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:40](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L40)
 
 ___
 
@@ -89,7 +89,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:19](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L19)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:19](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L19)
 
 ___
 
@@ -99,7 +99,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:34](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L34)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:34](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L34)
 
 ___
 
@@ -109,7 +109,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:37](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L37)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:37](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L37)
 
 ___
 
@@ -119,7 +119,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:10](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L10)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:10](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L10)
 
 ___
 
@@ -129,7 +129,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:25](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L25)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:25](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L25)
 
 ___
 
@@ -139,7 +139,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:31](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L31)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:31](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L31)
 
 ___
 
@@ -149,7 +149,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:13](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L13)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:13](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L13)
 
 ___
 
@@ -159,7 +159,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:28](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L28)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:28](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L28)
 
 ___
 
@@ -169,7 +169,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:22](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L22)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:22](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L22)
 
 ___
 
@@ -179,7 +179,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:16](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L16)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:16](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L16)
 
 ___
 
@@ -189,7 +189,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:42](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L42)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:42](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L42)
 
 ___
 
@@ -207,7 +207,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:47](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L47)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:47](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L47)
 
 ___
 
@@ -225,7 +225,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:52](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L52)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:52](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L52)
 
 ___
 
@@ -243,7 +243,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:53](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L53)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:53](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L53)
 
 ___
 
@@ -261,7 +261,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:44](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L44)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:44](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L44)
 
 ___
 
@@ -279,7 +279,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:49](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L49)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:49](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L49)
 
 ___
 
@@ -297,7 +297,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:51](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L51)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:51](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L51)
 
 ___
 
@@ -315,7 +315,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:45](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L45)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:45](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L45)
 
 ___
 
@@ -333,7 +333,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:50](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L50)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:50](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L50)
 
 ___
 
@@ -351,7 +351,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:48](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L48)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:48](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L48)
 
 ___
 
@@ -369,7 +369,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:46](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L46)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:46](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L46)
 
 ___
 
@@ -379,7 +379,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:39](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L39)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:39](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L39)
 
 ## Methods
 
@@ -393,7 +393,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:88](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L88)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:88](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L88)
 
 ___
 
@@ -411,7 +411,7 @@ OnDestroy.ngOnDestroy
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:70](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L70)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:70](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L70)
 
 ___
 
@@ -429,7 +429,7 @@ OnInit.ngOnInit
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:67](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L67)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:67](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L67)
 
 ___
 
@@ -443,7 +443,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:117](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L117)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:117](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L117)
 
 ___
 
@@ -457,7 +457,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:137](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L137)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:137](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L137)
 
 ___
 
@@ -471,7 +471,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:141](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L141)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:141](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L141)
 
 ___
 
@@ -485,7 +485,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:105](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L105)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:105](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L105)
 
 ___
 
@@ -499,7 +499,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:125](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L125)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:125](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L125)
 
 ___
 
@@ -513,7 +513,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:133](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L133)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:133](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L133)
 
 ___
 
@@ -527,7 +527,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:109](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L109)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:109](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L109)
 
 ___
 
@@ -541,7 +541,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:129](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L129)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:129](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L129)
 
 ___
 
@@ -555,7 +555,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:121](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L121)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:121](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L121)
 
 ___
 
@@ -569,4 +569,4 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:113](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L113)
+[projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts:113](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts#L113)

--- a/docs/classes/KoShapeComponent.md
+++ b/docs/classes/KoShapeComponent.md
@@ -27,7 +27,9 @@
 - [beforeUpdate](KoShapeComponent.md#beforeupdate)
 - [centerOrigin](KoShapeComponent.md#centerorigin)
 - [elementRef](KoShapeComponent.md#elementref)
+- [groupComponent](KoShapeComponent.md#groupcomponent)
 - [id](KoShapeComponent.md#id)
+- [layerComponent](KoShapeComponent.md#layercomponent)
 - [selector](KoShapeComponent.md#selector)
 - [shape](KoShapeComponent.md#shape)
 - [sub](KoShapeComponent.md#sub)
@@ -55,13 +57,15 @@
 
 ### constructor
 
-• **new KoShapeComponent**(`elementRef`)
+• **new KoShapeComponent**(`elementRef`, `layerComponent`, `groupComponent`)
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `elementRef` | `ElementRef`<`HTMLElement`\> |
+| `layerComponent` | [`KoLayerComponent`](KoLayerComponent.md) |
+| `groupComponent` | [`KoGroupComponent`](KoGroupComponent.md) |
 
 #### Overrides
 
@@ -69,7 +73,7 @@
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-shape.component.ts:36](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L36)
+[projects/ngx-konva/src/lib/components/ko-shape.component.ts:38](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L38)
 
 ## Properties
 
@@ -79,7 +83,7 @@
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-shape.component.ts:17](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L17)
+[projects/ngx-konva/src/lib/components/ko-shape.component.ts:19](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L19)
 
 ___
 
@@ -93,7 +97,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:33](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L33)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:34](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L34)
 
 ___
 
@@ -107,7 +111,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:34](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L34)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:35](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L35)
 
 ___
 
@@ -117,7 +121,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-shape.component.ts:32](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L32)
+[projects/ngx-konva/src/lib/components/ko-shape.component.ts:34](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L34)
 
 ___
 
@@ -127,7 +131,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-shape.component.ts:29](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L29)
+[projects/ngx-konva/src/lib/components/ko-shape.component.ts:31](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L31)
 
 ___
 
@@ -137,7 +141,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-shape.component.ts:26](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L26)
+[projects/ngx-konva/src/lib/components/ko-shape.component.ts:28](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L28)
 
 ___
 
@@ -147,7 +151,17 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-shape.component.ts:37](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L37)
+[projects/ngx-konva/src/lib/components/ko-shape.component.ts:39](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L39)
+
+___
+
+### groupComponent
+
+• `Private` **groupComponent**: [`KoGroupComponent`](KoGroupComponent.md)
+
+#### Defined in
+
+[projects/ngx-konva/src/lib/components/ko-shape.component.ts:41](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L41)
 
 ___
 
@@ -161,7 +175,17 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:17](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L17)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:18](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L18)
+
+___
+
+### layerComponent
+
+• `Private` **layerComponent**: [`KoLayerComponent`](KoLayerComponent.md)
+
+#### Defined in
+
+[projects/ngx-konva/src/lib/components/ko-shape.component.ts:40](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L40)
 
 ___
 
@@ -171,7 +195,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-shape.component.ts:34](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L34)
+[projects/ngx-konva/src/lib/components/ko-shape.component.ts:36](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L36)
 
 ___
 
@@ -181,7 +205,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-shape.component.ts:15](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L15)
+[projects/ngx-konva/src/lib/components/ko-shape.component.ts:17](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L17)
 
 ___
 
@@ -195,7 +219,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:31](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L31)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:32](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L32)
 
 ___
 
@@ -209,7 +233,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:23](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L23)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:24](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L24)
 
 ___
 
@@ -223,7 +247,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:29](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L29)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:30](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L30)
 
 ___
 
@@ -237,7 +261,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:26](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L26)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:27](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L27)
 
 ___
 
@@ -251,7 +275,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:20](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L20)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:21](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L21)
 
 ___
 
@@ -286,7 +310,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:15](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L15)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:15](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L15)
 
 ## Accessors
 
@@ -306,7 +330,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-shape.component.ts:19](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L19)
+[projects/ngx-konva/src/lib/components/ko-shape.component.ts:21](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L21)
 
 ## Methods
 
@@ -320,7 +344,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-shape.component.ts:62](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L62)
+[projects/ngx-konva/src/lib/components/ko-shape.component.ts:71](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L71)
 
 ___
 
@@ -334,7 +358,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-shape.component.ts:58](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L58)
+[projects/ngx-konva/src/lib/components/ko-shape.component.ts:67](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L67)
 
 ___
 
@@ -352,7 +376,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-shape.component.ts:48](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L48)
+[projects/ngx-konva/src/lib/components/ko-shape.component.ts:57](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L57)
 
 ___
 
@@ -370,7 +394,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:43](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L43)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:44](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L44)
 
 ___
 
@@ -392,7 +416,7 @@ OnInit.ngOnInit
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-shape.component.ts:44](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L44)
+[projects/ngx-konva/src/lib/components/ko-shape.component.ts:53](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L53)
 
 ___
 
@@ -416,7 +440,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:48](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L48)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:49](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L49)
 
 ___
 
@@ -430,4 +454,4 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-shape.component.ts:52](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L52)
+[projects/ngx-konva/src/lib/components/ko-shape.component.ts:61](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-shape.component.ts#L61)

--- a/docs/classes/KoStageAutoScaleComponent.md
+++ b/docs/classes/KoStageAutoScaleComponent.md
@@ -25,7 +25,6 @@
 - [afterUpdate](KoStageAutoScaleComponent.md#afterupdate)
 - [beforeUpdate](KoStageAutoScaleComponent.md#beforeupdate)
 - [cdRef](KoStageAutoScaleComponent.md#cdref)
-- [children](KoStageAutoScaleComponent.md#children)
 - [container](KoStageAutoScaleComponent.md#container)
 - [initialDimensions](KoStageAutoScaleComponent.md#initialdimensions)
 - [onNewLayer](KoStageAutoScaleComponent.md#onnewlayer)
@@ -39,6 +38,7 @@
 
 ### Methods
 
+- [addChild](KoStageAutoScaleComponent.md#addchild)
 - [ngAfterContentInit](KoStageAutoScaleComponent.md#ngaftercontentinit)
 - [ngAfterViewInit](KoStageAutoScaleComponent.md#ngafterviewinit)
 - [ngOnDestroy](KoStageAutoScaleComponent.md#ngondestroy)
@@ -66,7 +66,7 @@
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts:15](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts#L15)
+[projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts:15](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts#L15)
 
 ## Properties
 
@@ -80,7 +80,7 @@
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage.component.ts:26](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L26)
+[projects/ngx-konva/src/lib/components/ko-stage.component.ts:21](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L21)
 
 ___
 
@@ -94,7 +94,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage.component.ts:23](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L23)
+[projects/ngx-konva/src/lib/components/ko-stage.component.ts:18](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L18)
 
 ___
 
@@ -104,21 +104,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts:17](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts#L17)
-
-___
-
-### children
-
-• **children**: `QueryList`<[`KoNestable`](KoNestable.md)\>
-
-#### Inherited from
-
-[KoStageComponent](KoStageComponent.md).[children](KoStageComponent.md#children)
-
-#### Defined in
-
-[projects/ngx-konva/src/lib/components/ko-stage.component.ts:18](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L18)
+[projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts:17](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts#L17)
 
 ___
 
@@ -132,7 +118,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage.component.ts:15](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L15)
+[projects/ngx-konva/src/lib/components/ko-stage.component.ts:14](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L14)
 
 ___
 
@@ -142,7 +128,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts:12](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts#L12)
+[projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts:12](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts#L12)
 
 ___
 
@@ -156,7 +142,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage.component.ts:29](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L29)
+[projects/ngx-konva/src/lib/components/ko-stage.component.ts:24](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L24)
 
 ___
 
@@ -166,7 +152,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts:16](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts#L16)
+[projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts:16](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts#L16)
 
 ___
 
@@ -176,7 +162,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts:13](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts#L13)
+[projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts:13](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts#L13)
 
 ___
 
@@ -190,7 +176,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage.component.ts:20](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L20)
+[projects/ngx-konva/src/lib/components/ko-stage.component.ts:15](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L15)
 
 ## Accessors
 
@@ -214,9 +200,33 @@ KoStageComponent.config
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage.component.ts:34](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L34)
+[projects/ngx-konva/src/lib/components/ko-stage.component.ts:29](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L29)
 
 ## Methods
+
+### addChild
+
+▸ **addChild**(`layer`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `layer` | `Layer` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+[KoStageComponent](KoStageComponent.md).[addChild](KoStageComponent.md#addchild)
+
+#### Defined in
+
+[projects/ngx-konva/src/lib/components/ko-stage.component.ts:61](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L61)
+
+___
 
 ### ngAfterContentInit
 
@@ -232,7 +242,7 @@ AfterContentInit.ngAfterContentInit
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts:40](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts#L40)
+[projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts:40](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts#L40)
 
 ___
 
@@ -250,7 +260,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage.component.ts:58](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L58)
+[projects/ngx-konva/src/lib/components/ko-stage.component.ts:53](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L53)
 
 ___
 
@@ -272,7 +282,7 @@ OnDestroy.ngOnDestroy
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts:44](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts#L44)
+[projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts:44](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts#L44)
 
 ___
 
@@ -294,7 +304,7 @@ OnInit.ngOnInit
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts:36](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts#L36)
+[projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts:36](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts#L36)
 
 ___
 
@@ -308,7 +318,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts:49](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts#L49)
+[projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts:49](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts#L49)
 
 ___
 
@@ -322,4 +332,4 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts:53](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts#L53)
+[projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts:53](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts#L53)

--- a/docs/classes/KoStageComponent.md
+++ b/docs/classes/KoStageComponent.md
@@ -25,7 +25,6 @@
 - [\_config](KoStageComponent.md#_config)
 - [afterUpdate](KoStageComponent.md#afterupdate)
 - [beforeUpdate](KoStageComponent.md#beforeupdate)
-- [children](KoStageComponent.md#children)
 - [container](KoStageComponent.md#container)
 - [onNewLayer](KoStageComponent.md#onnewlayer)
 - [stage](KoStageComponent.md#stage)
@@ -37,10 +36,10 @@
 
 ### Methods
 
+- [addChild](KoStageComponent.md#addchild)
 - [ngAfterViewInit](KoStageComponent.md#ngafterviewinit)
 - [ngOnDestroy](KoStageComponent.md#ngondestroy)
 - [ngOnInit](KoStageComponent.md#ngoninit)
-- [updateLayers](KoStageComponent.md#updatelayers)
 - [updateStage](KoStageComponent.md#updatestage)
 
 ## Constructors
@@ -57,7 +56,7 @@
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage.component.ts:45](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L45)
+[projects/ngx-konva/src/lib/components/ko-stage.component.ts:40](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L40)
 
 ## Properties
 
@@ -67,7 +66,7 @@
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage.component.ts:31](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L31)
+[projects/ngx-konva/src/lib/components/ko-stage.component.ts:26](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L26)
 
 ___
 
@@ -77,7 +76,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage.component.ts:26](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L26)
+[projects/ngx-konva/src/lib/components/ko-stage.component.ts:21](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L21)
 
 ___
 
@@ -87,17 +86,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage.component.ts:23](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L23)
-
-___
-
-### children
-
-• **children**: `QueryList`<[`KoNestable`](KoNestable.md)\>
-
-#### Defined in
-
-[projects/ngx-konva/src/lib/components/ko-stage.component.ts:18](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L18)
+[projects/ngx-konva/src/lib/components/ko-stage.component.ts:18](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L18)
 
 ___
 
@@ -107,7 +96,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage.component.ts:15](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L15)
+[projects/ngx-konva/src/lib/components/ko-stage.component.ts:14](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L14)
 
 ___
 
@@ -117,7 +106,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage.component.ts:29](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L29)
+[projects/ngx-konva/src/lib/components/ko-stage.component.ts:24](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L24)
 
 ___
 
@@ -127,7 +116,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage.component.ts:20](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L20)
+[projects/ngx-konva/src/lib/components/ko-stage.component.ts:15](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L15)
 
 ___
 
@@ -137,7 +126,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage.component.ts:43](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L43)
+[projects/ngx-konva/src/lib/components/ko-stage.component.ts:38](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L38)
 
 ## Accessors
 
@@ -157,9 +146,29 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage.component.ts:34](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L34)
+[projects/ngx-konva/src/lib/components/ko-stage.component.ts:29](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L29)
 
 ## Methods
+
+### addChild
+
+▸ **addChild**(`layer`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `layer` | `Layer` |
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[projects/ngx-konva/src/lib/components/ko-stage.component.ts:61](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L61)
+
+___
 
 ### ngAfterViewInit
 
@@ -175,7 +184,7 @@ AfterViewInit.ngAfterViewInit
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage.component.ts:58](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L58)
+[projects/ngx-konva/src/lib/components/ko-stage.component.ts:53](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L53)
 
 ___
 
@@ -193,7 +202,7 @@ OnDestroy.ngOnDestroy
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage.component.ts:67](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L67)
+[projects/ngx-konva/src/lib/components/ko-stage.component.ts:56](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L56)
 
 ___
 
@@ -211,21 +220,7 @@ OnInit.ngOnInit
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage.component.ts:56](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L56)
-
-___
-
-### updateLayers
-
-▸ `Private` **updateLayers**(): `void`
-
-#### Returns
-
-`void`
-
-#### Defined in
-
-[projects/ngx-konva/src/lib/components/ko-stage.component.ts:72](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L72)
+[projects/ngx-konva/src/lib/components/ko-stage.component.ts:51](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L51)
 
 ___
 
@@ -239,4 +234,4 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage.component.ts:94](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L94)
+[projects/ngx-konva/src/lib/components/ko-stage.component.ts:74](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L74)

--- a/docs/classes/KoTransformDirective.md
+++ b/docs/classes/KoTransformDirective.md
@@ -46,7 +46,7 @@
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-transform.directive.ts:24](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-transform.directive.ts#L24)
+[projects/ngx-konva/src/lib/directives/ko-transform.directive.ts:24](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-transform.directive.ts#L24)
 
 ## Properties
 
@@ -56,7 +56,7 @@
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-transform.directive.ts:13](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-transform.directive.ts#L13)
+[projects/ngx-konva/src/lib/directives/ko-transform.directive.ts:13](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-transform.directive.ts#L13)
 
 ___
 
@@ -66,7 +66,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-transform.directive.ts:16](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-transform.directive.ts#L16)
+[projects/ngx-konva/src/lib/directives/ko-transform.directive.ts:16](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-transform.directive.ts#L16)
 
 ___
 
@@ -76,7 +76,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-transform.directive.ts:10](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-transform.directive.ts#L10)
+[projects/ngx-konva/src/lib/directives/ko-transform.directive.ts:10](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-transform.directive.ts#L10)
 
 ___
 
@@ -86,7 +86,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-transform.directive.ts:18](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-transform.directive.ts#L18)
+[projects/ngx-konva/src/lib/directives/ko-transform.directive.ts:18](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-transform.directive.ts#L18)
 
 ___
 
@@ -104,7 +104,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-transform.directive.ts:22](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-transform.directive.ts#L22)
+[projects/ngx-konva/src/lib/directives/ko-transform.directive.ts:22](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-transform.directive.ts#L22)
 
 ___
 
@@ -122,7 +122,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-transform.directive.ts:21](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-transform.directive.ts#L21)
+[projects/ngx-konva/src/lib/directives/ko-transform.directive.ts:21](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-transform.directive.ts#L21)
 
 ___
 
@@ -140,7 +140,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-transform.directive.ts:20](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-transform.directive.ts#L20)
+[projects/ngx-konva/src/lib/directives/ko-transform.directive.ts:20](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-transform.directive.ts#L20)
 
 ## Methods
 
@@ -154,7 +154,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-transform.directive.ts:45](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-transform.directive.ts#L45)
+[projects/ngx-konva/src/lib/directives/ko-transform.directive.ts:45](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-transform.directive.ts#L45)
 
 ___
 
@@ -172,7 +172,7 @@ OnDestroy.ngOnDestroy
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-transform.directive.ts:38](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-transform.directive.ts#L38)
+[projects/ngx-konva/src/lib/directives/ko-transform.directive.ts:38](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-transform.directive.ts#L38)
 
 ___
 
@@ -190,7 +190,7 @@ OnInit.ngOnInit
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-transform.directive.ts:35](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-transform.directive.ts#L35)
+[projects/ngx-konva/src/lib/directives/ko-transform.directive.ts:35](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-transform.directive.ts#L35)
 
 ___
 
@@ -204,7 +204,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-transform.directive.ts:59](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-transform.directive.ts#L59)
+[projects/ngx-konva/src/lib/directives/ko-transform.directive.ts:59](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-transform.directive.ts#L59)
 
 ___
 
@@ -218,7 +218,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-transform.directive.ts:55](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-transform.directive.ts#L55)
+[projects/ngx-konva/src/lib/directives/ko-transform.directive.ts:55](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-transform.directive.ts#L55)
 
 ___
 
@@ -232,4 +232,4 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/directives/ko-transform.directive.ts:51](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/directives/ko-transform.directive.ts#L51)
+[projects/ngx-konva/src/lib/directives/ko-transform.directive.ts:51](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/directives/ko-transform.directive.ts#L51)

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -44,7 +44,7 @@
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-image.component.ts:6](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-image.component.ts#L6)
+[projects/ngx-konva/src/lib/components/ko-image.component.ts:8](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-image.component.ts#L8)
 
 ___
 
@@ -54,7 +54,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:11](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L11)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:11](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L11)
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/ko-nestable.ts:10](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/ko-nestable.ts#L10)
+[projects/ngx-konva/src/lib/common/ko-nestable.ts:10](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/ko-nestable.ts#L10)
 
 ___
 
@@ -74,7 +74,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/index.ts:21](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/index.ts#L21)
+[projects/ngx-konva/src/lib/common/index.ts:21](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/index.ts#L21)
 
 ___
 
@@ -84,7 +84,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/index.ts:17](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/index.ts#L17)
+[projects/ngx-konva/src/lib/common/index.ts:17](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/index.ts#L17)
 
 ___
 
@@ -94,7 +94,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/index.ts:18](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/index.ts#L18)
+[projects/ngx-konva/src/lib/common/index.ts:18](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/index.ts#L18)
 
 ___
 
@@ -104,7 +104,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/index.ts:19](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/index.ts#L19)
+[projects/ngx-konva/src/lib/common/index.ts:19](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/index.ts#L19)
 
 ___
 
@@ -114,7 +114,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/index.ts:20](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/index.ts#L20)
+[projects/ngx-konva/src/lib/common/index.ts:20](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/index.ts#L20)
 
 ___
 
@@ -124,7 +124,7 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/components/ko-stage.component.ts:7](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L7)
+[projects/ngx-konva/src/lib/components/ko-stage.component.ts:6](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/components/ko-stage.component.ts#L6)
 
 ## Variables
 
@@ -134,4 +134,4 @@ ___
 
 #### Defined in
 
-[projects/ngx-konva/src/lib/common/index.ts:22](https://github.com/giovanni-bertoncelli/ngx-konva/blob/d94ca4c/projects/ngx-konva/src/lib/common/index.ts#L22)
+[projects/ngx-konva/src/lib/common/index.ts:22](https://github.com/giovanni-bertoncelli/ngx-konva/blob/a56f97a/projects/ngx-konva/src/lib/common/index.ts#L22)

--- a/projects/ngx-konva/src/lib/common/ko-nestable.ts
+++ b/projects/ngx-konva/src/lib/common/ko-nestable.ts
@@ -14,6 +14,7 @@ export type KoNestableConfig = (KoShapeConfig | GroupConfig | LayerConfig | Labe
 export class KoNestable implements OnInit, OnDestroy {
   static Easings = Easings;
 
+  @Input()
   id: string = v4();
 
   @Input()

--- a/projects/ngx-konva/src/lib/components/ko-image.component.ts
+++ b/projects/ngx-konva/src/lib/components/ko-image.component.ts
@@ -1,7 +1,9 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Optional, Output } from '@angular/core';
 import { ImageConfig, Image as KonvaImage } from 'konva/lib/shapes/Image';
 import { KoShape } from '../common';
 import { KoNestable, KoNestableConfig } from '../common/ko-nestable';
+import { KoGroupComponent } from './ko-group.component';
+import { KoLayerComponent } from './ko-layer.component';
 
 export type KoImageConfig = Omit<ImageConfig, 'image'>;
 
@@ -45,12 +47,20 @@ export class KoImageComponent extends KoNestable implements OnInit {
 
   onLoadListener = this.onImageLoad.bind(this);
 
-  constructor() {
+  constructor(
+    @Optional() private layerComponent: KoLayerComponent,
+    @Optional() private groupComponent: KoGroupComponent
+  ) {
+    if (!layerComponent && !groupComponent) {
+      throw new Error(`ko-image should be nested inside ko-layer!`)
+    }
+
     super();
     this.node = new KonvaImage({
       ...this._config,
       image: this._image
-    })
+    });
+    (this.groupComponent || this.layerComponent).addChild(this.node);
     this._image.addEventListener('load', this.onLoadListener);
   }
 

--- a/projects/ngx-konva/src/lib/components/ko-label.component.ts
+++ b/projects/ngx-konva/src/lib/components/ko-label.component.ts
@@ -1,7 +1,9 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Optional, Output } from '@angular/core';
 import { Label, Tag, TagConfig } from 'konva/lib/shapes/Label';
 import { Text, TextConfig } from 'konva/lib/shapes/Text';
 import { KoNestable, KoNestableConfig } from '../common/ko-nestable';
+import { KoGroupComponent } from './ko-group.component';
+import { KoLayerComponent } from './ko-layer.component';
 
 @Component({
   selector: 'ko-label',
@@ -66,9 +68,15 @@ export class KoLabelComponent extends KoNestable implements OnInit {
   @Output()
   afterUpdate = new EventEmitter<Label>();
 
-  constructor() {
-    super();
+  constructor(
+    @Optional() private layerComponent: KoLayerComponent,
+    @Optional() private groupComponent: KoGroupComponent
+  ) {
+    if (!layerComponent && !groupComponent) {
+      throw new Error(`ko-label should be nested inside ko-layer!`)
+    }
 
+    super();
     this.node = new Label(this._config);
     this.text = new Text(this._textConfig);
     this.tag = new Tag(this._tagConfig);
@@ -76,6 +84,7 @@ export class KoLabelComponent extends KoNestable implements OnInit {
     this.node
       .add(this.tag)
       .add(this.text);
+    (this.groupComponent || this.layerComponent).addChild(this.node);
   }
 
   override ngOnDestroy(): void {

--- a/projects/ngx-konva/src/lib/components/ko-shape.component.ts
+++ b/projects/ngx-konva/src/lib/components/ko-shape.component.ts
@@ -1,6 +1,8 @@
-import { Component, ElementRef, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { Component, ElementRef, EventEmitter, Input, OnInit, Optional, Output } from '@angular/core';
 import { KoShape, KoShapeConfig, KoShapeSelectors, koShapeTypesMap } from '../common';
 import { KoNestable } from '../common/ko-nestable';
+import { KoGroupComponent } from './ko-group.component';
+import { KoLayerComponent } from './ko-layer.component';
 
 @Component({
   selector: 'ko-circle, ko-rect, ko-line, ko-text, ko-regular-polygon, ko-path, ko-arrow, ko-arc, ko-star, ko-ring, ko-shape, ko-text-path, ko-ellipse, ko-wedge',
@@ -34,11 +36,18 @@ export class KoShapeComponent extends KoNestable implements OnInit {
   selector: KoShapeSelectors;
 
   constructor(
-    private elementRef: ElementRef<HTMLElement>
+    private elementRef: ElementRef<HTMLElement>,
+    @Optional() private layerComponent: KoLayerComponent,
+    @Optional() private groupComponent: KoGroupComponent
   ) {
     super();
     this.selector = this.elementRef.nativeElement.localName as KoShapeSelectors;
-    this.shape = new (koShapeTypesMap[this.selector] as any)(this._config as any)
+    if (!layerComponent && !groupComponent) {
+      throw new Error(`${this.selector} should be nested inside ko-layer or ko-group!`)
+    }
+
+    this.shape = new (koShapeTypesMap[this.selector] as any)(this._config as any);
+    (this.groupComponent || this.layerComponent).addChild(this.shape);
   }
 
   override ngOnInit(): void {

--- a/projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts
+++ b/projects/ngx-konva/src/lib/components/ko-stage-autoscale.component.ts
@@ -1,4 +1,4 @@
-import { AfterContentInit, ChangeDetectorRef, Component, ElementRef, OnDestroy, OnInit, Optional, SkipSelf } from '@angular/core';
+import { AfterContentInit, ChangeDetectorRef, Component, ElementRef, OnDestroy, OnInit, SkipSelf } from '@angular/core';
 import { KoStageComponent } from './ko-stage.component';
 
 @Component({
@@ -6,18 +6,21 @@ import { KoStageComponent } from './ko-stage.component';
   template: `
       <ng-content></ng-content>
   `,
-  styles: [``]
+  styles: [``],
+  providers: [{
+    provide: KoStageComponent,
+    useExisting: KoStageAutoScaleComponent
+  }]
 })
 export class KoStageAutoScaleComponent extends KoStageComponent implements OnInit, OnDestroy, AfterContentInit {
   private initialDimensions: { width: number, height: number } | null = null;
   private resizeObserver = new ResizeObserver(this.onResize.bind(this));
 
   constructor(
-    @SkipSelf() @Optional() private parentContainer: ElementRef<HTMLDivElement>,
+    @SkipSelf() private parentContainer: ElementRef<HTMLDivElement>,
     private cdRef: ChangeDetectorRef,
-    @Optional() container: ElementRef
   ) {
-    super(container);
+    super(parentContainer);
     if (!parentContainer) {
       throw new Error(
         'ko-stage-autoscale should be nested inside a div/element!'

--- a/projects/ngx-konva/src/lib/components/ko-stage.component.ts
+++ b/projects/ngx-konva/src/lib/components/ko-stage.component.ts
@@ -60,7 +60,6 @@ export class KoStageComponent implements OnInit, OnDestroy, AfterViewInit {
 
   addChild(layer: Layer) {
     const found = this.stage.findOne(`#${layer.id()}`);
-    console.log(layer, found)
     if (found) {
       return;
     }

--- a/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts
+++ b/projects/ngx-konva/src/lib/directives/ko-mouse.directive.ts
@@ -1,0 +1,148 @@
+import { Directive, EventEmitter, OnDestroy, OnInit, Optional, Output, Self } from '@angular/core';
+import { Subscription } from 'rxjs';
+import { KoNestable, KoNestableNode } from '../common/ko-nestable';
+import { KoStageComponent } from '../components/ko-stage.component';
+
+@Directive({
+  selector: '[koMouse]'
+})
+export class KoMouseDirective implements OnInit, OnDestroy {
+  @Output()
+  koMouseDown = new EventEmitter<KoNestableNode>();
+
+  @Output()
+  koMouseMove = new EventEmitter<KoNestableNode>();
+
+  @Output()
+  koMouseUp = new EventEmitter<KoNestableNode>();
+
+  @Output()
+  koMouseLeave = new EventEmitter<KoNestableNode>();
+
+  @Output()
+  koMouseOver = new EventEmitter<KoNestableNode>();
+
+  @Output()
+  koMouseEnter = new EventEmitter<KoNestableNode>();
+
+  @Output()
+  koMouseWheel = new EventEmitter<KoNestableNode>();
+
+  @Output()
+  koMouseOut = new EventEmitter<KoNestableNode>();
+
+  @Output()
+  koClick = new EventEmitter<KoNestableNode>();
+
+  @Output()
+  koDblclick = new EventEmitter<KoNestableNode>();
+
+  sub = new Subscription();
+  hovering = false;
+
+  private node: KoNestableNode;
+
+  onMouseDownListener = this.onMouseDown.bind(this);
+  onMouseMoveListener = this.onMouseMove.bind(this);
+  onMouseUpListener = this.onMouseUp.bind(this);
+  onMouseLeaveListener = this.onMouseLeave.bind(this);
+  onMouseOverListener = this.onMouseOver.bind(this);
+  onMouseEnterListener = this.onMouseEnter.bind(this);
+  onMouseOutListener = this.onMouseOut.bind(this);
+  onMouseWheelListener = this.onMouseWheel.bind(this);
+  onClickListener = this.onClick.bind(this);
+  onDblclickListener = this.onDblclick.bind(this);
+
+
+  constructor(
+    @Optional() @Self() nestable: KoNestable,
+    @Optional() @Self() stage: KoStageComponent,
+  ) {
+    if (!nestable && !stage) {
+      throw new Error('koMouse attachable only to ko-shape or ko-stage');
+    }
+
+    this.node = (nestable && nestable.getKoItem()) ||
+      (stage && stage.stage);
+    this.addListeners();
+  }
+
+  ngOnInit(): void {
+  }
+
+  ngOnDestroy(): void {
+    this.sub.unsubscribe();
+
+    if (this.node) {
+      this.node.off('mousedown', this.onMouseDownListener);
+      this.node.off('mousemove', this.onMouseMoveListener);
+      this.node.off('mouseup', this.onMouseUpListener);
+      this.node.off('mouseover', this.onMouseOverListener);
+      this.node.off('mouseenter', this.onMouseEnterListener);
+      this.node.off('mouseout', this.onMouseOutListener);
+      this.node.off('mouseleave', this.onMouseLeaveListener);
+      this.node.off('wheel', this.onMouseWheelListener);
+      this.node.off('click', this.onClickListener);
+      this.node.off('dblclick', this.onDblclickListener);
+    }
+  }
+
+
+  addListeners() {
+    if (!this.node) {
+      return;
+    }
+
+    this.node.on('mousedown', this.onMouseDownListener);
+    this.node.on('mousemove', this.onMouseMoveListener);
+    this.node.on('mouseup', this.onMouseUpListener);
+    this.node.on('mouseover', this.onMouseOverListener);
+    this.node.on('mouseenter', this.onMouseEnterListener);
+    this.node.on('mouseout', this.onMouseOutListener);
+    this.node.on('wheel', this.onMouseWheelListener);
+    this.node.on('mouseleave', this.onMouseLeaveListener);
+    this.node.on('click', this.onClickListener);
+    this.node.on('dblclick', this.onDblclickListener);
+  }
+
+  onMouseWheel() {
+    this.koMouseWheel.emit(this.node);
+  }
+
+  onMouseDown() {
+    this.koMouseDown.emit(this.node);
+  }
+
+  onMouseMove() {
+    this.koMouseMove.emit(this.node);
+  }
+
+  onMouseUp() {
+    this.koMouseUp.emit(this.node);
+  }
+
+  onMouseOver() {
+    this.koMouseOver.emit(this.node);
+  }
+
+  onMouseEnter() {
+    this.koMouseEnter.emit(this.node);
+  }
+
+  onMouseOut() {
+    this.koMouseOut.emit(this.node);
+  }
+
+  onMouseLeave() {
+    this.koMouseLeave.emit(this.node);
+  }
+
+  onClick() {
+    this.koClick.emit(this.node);
+  }
+
+  onDblclick() {
+    this.koDblclick.emit(this.node);
+  }
+
+}

--- a/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts
+++ b/projects/ngx-konva/src/lib/directives/ko-pointer.directive.ts
@@ -1,6 +1,7 @@
 import { Directive, EventEmitter, OnDestroy, OnInit, Optional, Output, Self } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { KoNestable, KoNestableNode } from '../common/ko-nestable';
+import { KoStageComponent } from '../components/ko-stage.component';
 
 @Directive({
   selector: '[koPointer]'
@@ -54,13 +55,15 @@ export class KoPointerDirective implements OnInit, OnDestroy {
 
 
   constructor(
-    @Optional() @Self() nestable: KoNestable
+    @Optional() @Self() nestable: KoNestable,
+    @Optional() @Self() stage: KoStageComponent,
   ) {
-    if (!nestable) {
-      throw new Error('koPointer attachable only to ko-shape');
+    if (!nestable && !stage) {
+      throw new Error('koPointer attachable only to ko-shape or ko-stage');
     }
 
-    this.node = nestable.getKoItem();
+    this.node = (nestable && nestable.getKoItem()) ||
+      (stage && stage.stage);
     this.addListeners();
   }
 

--- a/projects/ngx-konva/src/lib/ngx-konva.module.ts
+++ b/projects/ngx-konva/src/lib/ngx-konva.module.ts
@@ -9,6 +9,7 @@ import { KoStageAutoScaleComponent } from './components/ko-stage-autoscale.compo
 import { KoStageComponent } from './components/ko-stage.component';
 import { KoDragDirective } from './directives/ko-drag.directive';
 import { KoHoverDirective } from './directives/ko-hover.directive';
+import { KoMouseDirective } from './directives/ko-mouse.directive';
 import { KoPointerDirective } from './directives/ko-pointer.directive';
 import { KoTransformDirective } from './directives/ko-transform.directive';
 
@@ -24,7 +25,8 @@ import { KoTransformDirective } from './directives/ko-transform.directive';
     KoImageComponent,
     KoLabelComponent,
     KoDragDirective,
-    KoTransformDirective
+    KoTransformDirective,
+    KoMouseDirective
   ],
   imports: [CommonModule],
   exports: [
@@ -38,7 +40,8 @@ import { KoTransformDirective } from './directives/ko-transform.directive';
     KoImageComponent,
     KoLabelComponent,
     KoDragDirective,
-    KoTransformDirective
+    KoTransformDirective,
+    KoMouseDirective
   ],
   providers: [],
 })

--- a/projects/ngx-konva/src/public-api.ts
+++ b/projects/ngx-konva/src/public-api.ts
@@ -13,6 +13,7 @@ export * from './lib/components/ko-stage-autoscale.component';
 export * from './lib/components/ko-stage.component';
 export * from './lib/directives/ko-drag.directive';
 export * from './lib/directives/ko-hover.directive';
+export * from './lib/directives/ko-mouse.directive';
 export * from './lib/directives/ko-pointer.directive';
 export * from './lib/directives/ko-transform.directive';
 export * from './lib/ngx-konva.module';

--- a/projects/ngx-konva/tsconfig.lib.json
+++ b/projects/ngx-konva/tsconfig.lib.json
@@ -10,7 +10,8 @@
     "lib": [
       "es6",
       "DOM"
-    ]
+    ],
+    "sourceMap": true
   },
   "exclude": [
     "**/*.spec.ts"


### PR DESCRIPTION
## Fixed

- Hierarchy resolution passed to bottom -> up instead of up -> bottom in order to avoid unresolvable KoNestable nested inside other components and not reachable from @ContentChildren directive (https://stackoverflow.com/questions/52653376/angular-using-contentchildren-to-get-children-inside-another-component)